### PR TITLE
Refactored code for use as a library

### DIFF
--- a/communicator/winrm/communicator.go
+++ b/communicator/winrm/communicator.go
@@ -1,4 +1,4 @@
-package main
+package winrm
 
 import (
 	"fmt"

--- a/communicator/winrm/communicator_test.go
+++ b/communicator/winrm/communicator_test.go
@@ -1,4 +1,4 @@
-package main
+package winrm
 
 import (
 	"bytes"

--- a/communicator/winrm/file_manager.go
+++ b/communicator/winrm/file_manager.go
@@ -1,4 +1,4 @@
-package main
+package winrm
 
 import (
 	"encoding/base64"

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	plugin "github.com/dylanmei/packer-communicator-winrm/communicator/winrm"
 	"github.com/masterzen/winrm/winrm"
 	"github.com/mitchellh/packer/packer"
 	rpc "github.com/mitchellh/packer/packer/plugin"
@@ -26,7 +27,7 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		server.RegisterCommunicator(new(Communicator))
+		server.RegisterCommunicator(new(plugin.Communicator))
 		server.Serve()
 	}
 }
@@ -48,7 +49,7 @@ func (r *RunCommand) Flags(fs *flag.FlagSet) *flag.FlagSet {
 func (r *RunCommand) Run(args []string) {
 	command := args[0]
 
-	communicator, err := New(&winrm.Endpoint{*host, *port}, *user, *pass, *timeout)
+	communicator, err := plugin.New(&winrm.Endpoint{*host, *port}, *user, *pass, *timeout)
 	rc := &packer.RemoteCmd{
 		Command: command,
 		Stdout:  os.Stdout,
@@ -80,7 +81,7 @@ func (f *FileCommand) Flags(fs *flag.FlagSet) *flag.FlagSet {
 }
 
 func (f *FileCommand) Run(args []string) {
-	communicator, err := New(&winrm.Endpoint{*host, *port}, *user, *pass, *timeout)
+	communicator, err := plugin.New(&winrm.Endpoint{*host, *port}, *user, *pass, *timeout)
 
 	info, err := os.Stat(*f.from)
 	if err != nil {
@@ -110,7 +111,7 @@ func (f *DirCommand) Flags(fs *flag.FlagSet) *flag.FlagSet {
 }
 
 func (f *DirCommand) Run(args []string) {
-	communicator, _ := New(&winrm.Endpoint{*host, *port}, *user, *pass, *timeout)
+	communicator, _ := plugin.New(&winrm.Endpoint{*host, *port}, *user, *pass, *timeout)
 
 	_, err := os.Stat(*f.from)
 	if err != nil {


### PR DESCRIPTION
This PR allows the communicator to be used as a standalone CLI tool or included in another project as an imported library. Currently, as all packages are contained within `main` this package cannot be included in other libraries (see https://travis-ci.org/mefellows/packer-winrm-shell/jobs/42291291#L116 as an example build failing).

Builds fail with errors like below:

```
imports github.com/dylanmei/packer-communicator-winrm/communicator/winrm: cannot find package "github.com/dylanmei/packer-communicator-winrm/communicator/winrm" in any of:
/usr/local/go/src/pkg/github.com/dylanmei/packer-communicator-winrm/communicator/winrm (from $GOROOT)
/home/ubuntu/go/src/github.com/dylanmei/packer-communicator-winrm/communicator/winrm (from $GOPATH)
```
